### PR TITLE
Bugfixes - dismissed reminder was not being removed from list; rename of snoozed reminder now prevented

### DIFF
--- a/AudioReminderRingerListener/MainLoop.cs
+++ b/AudioReminderRingerListener/MainLoop.cs
@@ -13,6 +13,7 @@ namespace AudioReminderRingerListener
 
     class MainLoop
     {
+        //TODO: change code to use different pipes or handle async issues in some other way because currently beep can't be played until ringing dialog is open - and after that it plays late! It could probably be played multiple times in that case.
         public static void RunLoop()
         {
             do

--- a/AudioReminderRinging/ReminderRingingForm.cs
+++ b/AudioReminderRinging/ReminderRingingForm.cs
@@ -17,6 +17,8 @@ namespace AudioReminderRinging
 {
     public partial class ReminderRingingForm : Form
     {
+        //TODO: handle service unavilable + handle disable of snooze button when snooze is disabled (otherwise it will crash)
+
         protected virtual AudioReminderWebServiceClient Proxy { get; set; }
         protected virtual ReminderEntity Reminder { get; set; }
 
@@ -87,6 +89,7 @@ namespace AudioReminderRinging
             if (reminderName == NamedPipeHelper.TestReminderName)
             {
                 IsTestMode = true;
+                this.Text = "Reminder ringing: " + "test reminder";
                 Log.Logger.Information($"Ringer started just as an ringing example. Snooze/dismiss will have no effect.");
                 return true;
             }
@@ -98,7 +101,9 @@ namespace AudioReminderRinging
                 Log.Logger.Fatal($"Reminder with given name could not be found. Closing application. ");
                 return false;
             }
-
+            
+            this.Text = "Reminder ringing: " + Reminder.Name;
+            
             return true;
         }
 

--- a/AudioReminderService/Scheduler/TimerBased/ReminderScheduling/NextReminderNotifier.cs
+++ b/AudioReminderService/Scheduler/TimerBased/ReminderScheduling/NextReminderNotifier.cs
@@ -107,7 +107,8 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
                 return;
             }
 
-            Log.Logger.Information($"Firing OnReminderElapsed event for [name = {elapsedReminder.Name}] so that it can be added to elapsed reimnders list");
+            //UserInteraction manager already logs receival of this event
+            //Log.Logger.Information($"Firing OnReminderElapsed event for [name = {elapsedReminder.Name}] so that it can be added to elapsed reimnders list");
 
             //Add reminder to list of elapsed reminders
             OnReminderElapsed(elapsedReminder, now);
@@ -177,7 +178,7 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
 
         protected virtual List<ReminderEntity> CloneAndSortOnlyActiveReminders(IList<ReminderEntity> allReminders)
         {
-            List<ReminderEntity> onlyActiveReminders = ActiveSortedReminders = allReminders
+            List<ReminderEntity> onlyActiveReminders = allReminders
                             .Where(r => !r.Dismissed)
                             .Select(r => (ReminderEntity)r.Clone()) //TODO: check later how will this cloning be compatible with reminder ID, will we duplicate it also?
                             .OrderBy(r => r.ScheduledTime)
@@ -213,7 +214,7 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
             
             int intervalMs = GetTimeInMsUntilNextRinging(nextReminder, now);
 
-            Log.Logger.Information($"Starting NextReminderNotifier timer [Reminder name = {nextReminder.Name}, Interval = {intervalMs} ms] ");
+            Log.Logger.Information($"Starting NextReminderNotifier timer [Reminder name = {nextReminder.Name}, Interval = {intervalMs} ms, Scheduled at {nextReminder.ScheduledTime} UTC] ");
             
             NextReminderTimer.Interval = intervalMs;
             NextReminderTimer.Start();

--- a/AudioReminderService/Scheduler/TimerBased/ReminderScheduling/UserInteractionManager.cs
+++ b/AudioReminderService/Scheduler/TimerBased/ReminderScheduling/UserInteractionManager.cs
@@ -202,7 +202,7 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
                 reminderEntity.Dismissed = true;
             }
 
-            ElapsedActiveReminders.Remove(reminderEntity);
+            ElapsedActiveReminders.RemoveAll(r => r.Name == reminderEntity.Name);
 
             //TODO: test this - we are here potenitally calling ringer again before response for Dismissing is returned.
             GoToRingingOrIdleState(now);
@@ -231,7 +231,7 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
             else
             {
                 UserState = UserInteractionState.NoElapsedReminders;
-                Log.Logger.Information($"No more elapsed reminders in the list. GoToRingingOrIdleState method is setting state to NoElapsedReminders");
+                Log.Logger.Information($"No elapsed reminders in the list. GoToRingingOrIdleState method is setting state to NoElapsedReminders");
             }
         }
 
@@ -440,7 +440,6 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
                 else
                 {
                     remindersToBeRemoved.Add(elapsedReminder);
-                    //TODO: handle scenario wehere this is consequence of renaming elapsed remiinder, because would be able to bypass preventing of "deletion" of elapsed timers (whcih is in plan to be added)
                 }
             }
 
@@ -452,7 +451,7 @@ namespace AudioReminderService.Scheduler.TimerBased.ReminderScheduling
 
             foreach (ReminderEntity reminderToBeRemoved in remindersToBeRemoved)
             {
-                ElapsedActiveReminders.Remove(reminderToBeRemoved);
+                ElapsedActiveReminders.RemoveAll(r => r.Name == reminderToBeRemoved.Name);
             }
 
 

--- a/AudioReminderService/WebService/AudioReminderWebservice.cs
+++ b/AudioReminderService/WebService/AudioReminderWebservice.cs
@@ -66,8 +66,9 @@ namespace AudioReminderService.WebService
         {
             Log.Logger.Information($"Executing webservice operation \"{MethodBase.GetCurrentMethod().Name}\" [reminderOldName = {reminderOldName}]");
 
-            if (!AudioReminderService.scheduler.IsOkToModifyReminder(reminder.Name)) //TODO put nullcheck somwhere
+            if (!AudioReminderService.scheduler.IsOkToModifyReminder(reminderOldName))
             {
+                Log.Logger.Information($"It's NOT OK to change reminder with name [reminderOldName = {reminderOldName}]");
                 return false;
             }
 
@@ -77,6 +78,7 @@ namespace AudioReminderService.WebService
 
             FilePersistenceAdapters.RemiderFilePersistence.OnEntitesChanged();
 
+            Log.Logger.Information($"It's OK to change reminder with name [reminderOldName = {reminderOldName}]");
             return true;
         }
 


### PR DESCRIPTION
- Dismissed reminder was not being removed from the list in NextReminderNotifier
- Snoozed reminder now can't be renamed (Modifying or deleting it was already prevented) - this prevents stall reminders data in list of elapsed reminders in UI manager which could trigger ringing of a reminder by the old names
- Improved title of ringing app