### PR TITLE
Fixed test expectation; Added test case and refactored the tests

### DIFF
--- a/AudioReminderUnitTests/UnitTest1.cs
+++ b/AudioReminderUnitTests/UnitTest1.cs
@@ -7,33 +7,66 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace AudioReminderUnitTests
 {
     [TestClass]
-    public class UnitTest1
+    public class UnitTests
     {
+        /// <summary>
+        /// sunday, 1 hour before ringing time, next ringing is on monday
+        /// </summary>
         [TestMethod]
-        public void TestMethod1()
+        public void Test_WorkdayReminder_OnSunday_NextShouldbeMonday()
+        {
+            ReminderEntity weekly8am = CreateWeekly8amReminder();
+            var calc = new NextReminderOccurenceCalculator();
+
+            
+            DateTime now1 = new DateTime(2020, 4, 13, 7, 0, 0);
+            DateTime expectedNextOccurence1 = new DateTime(2020, 4, 13, 8, 0, 0);
+            
+            TestNextReminderOccurenceCalculation(weekly8am, calc, now1, expectedNextOccurence1);
+
+        }
+
+        /// <summary>
+        /// monday, 1 hour later than the ringing time, next ringing is on tuesday
+        /// </summary>
+        [TestMethod]
+        public void Test_WorkdayReminder_1hourAfterRing_NextShouldbeTomorrow()
+        {
+            ReminderEntity weekly8am = CreateWeekly8amReminder();
+            var calc = new NextReminderOccurenceCalculator();
+
+            DateTime now2 = new DateTime(2020, 4, 13, 9, 0, 0);
+            DateTime expectedNextOccurence2 = new DateTime(2020, 4, 14, 8, 0, 0);
+            TestNextReminderOccurenceCalculation(weekly8am, calc, now2, expectedNextOccurence2);
+        }
+
+        /// <summary>
+        /// monday, 1 hour before ringing time, next ringing should be in an hour
+        /// </summary>
+        [TestMethod]
+        public void Test_WorkdayReminder_1hourBeforeRing_NextShouldbeToday()
+        {
+            ReminderEntity weekly8am = CreateWeekly8amReminder();
+            var calc = new NextReminderOccurenceCalculator();
+
+            DateTime now3 = new DateTime(2020, 4, 13, 7, 0, 0);
+            DateTime expectedNextOccurence3 = new DateTime(2020, 4, 13, 8, 0, 0);
+            TestNextReminderOccurenceCalculation(weekly8am, calc, now3, expectedNextOccurence3);
+        }
+
+        private static ReminderEntity CreateWeekly8amReminder()
         {
             //TODO: put this in a test fixture
-            ReminderEntity weekly8am = new ReminderEntity()
+            return new ReminderEntity()
             {
                 Name = "Some event on workdays",
                 ScheduledTime = new DateTime(2020, 4, 10, 8, 0, 0),
                 RepeatPeriod = RepeatPeriod.Weekly,
                 RepeatWeeklyDays = new bool[] { true, true, true, true, true, false, false }
             };
-
-            var calc = new NextReminderOccurenceCalculator();
-
-            DateTime now1 = new DateTime(2020, 4, 11, 9, 0, 0);
-            DateTime expectedNextOccurence1 = new DateTime(2020, 4, 12, 8, 0, 0);
-            Test111(weekly8am, calc, now1, expectedNextOccurence1);
-
-            DateTime now2 = new DateTime(2020, 4, 11, 7, 0, 0);
-            DateTime expectedNextOccurence2 = new DateTime(2020, 4, 11, 8, 0, 0);
-            Test111(weekly8am, calc, now2, expectedNextOccurence2);
-            
         }
 
-        private static void Test111(ReminderEntity weekly8am, NextReminderOccurenceCalculator calc, DateTime now, DateTime expectedNextOccurence)
+        private static void TestNextReminderOccurenceCalculation(ReminderEntity weekly8am, NextReminderOccurenceCalculator calc, DateTime now, DateTime expectedNextOccurence)
         {
             var actualnextOccurence = calc.GetNextReminderOccurence(weekly8am, now).Value;
             Assert.AreEqual(expectedNextOccurence, actualnextOccurence);


### PR DESCRIPTION
In test it was falsely expected that workday reminder would fire during weekend.